### PR TITLE
fix: Upgraded dependencies and edition to latest version in cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "casbin-grpc"
 version = "0.1.0"
 authors = ["hackerchai <i@hackerchai.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic = "0.5"
-prost = "0.8"
-serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.6.1", features = ["full", "rt-multi-thread", "macros"] }
-casbin = "2.0.7"
-serde_json = "1.0"
-regex = "1.5.4"
+tonic = "0.7.2"
+prost = "0.10.3"
+serde = { version = "1.0.137", features = ["derive"] }
+tokio = { version = "1.18.1", features = ["full", "rt-multi-thread", "macros"] }
+casbin = "2.0.9"
+serde_json = "1.0.81"
+regex = "1.5.5"
 
 [build-dependencies]
-tonic-build = "0.5"
+tonic-build = "0.7.2"


### PR DESCRIPTION
I have done very initial migration towards Rust 2021. It seems that the build fails for project with multiple errors and complete migration will require some time until I am able to resolve all the errors and make project compile successfully.